### PR TITLE
chore: bump upstream version to latest

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target') && github.repository_owner == 'cowprotocol' && github.repository != 'cowprotocol/cla'
-        uses: contributor-assistant/github-action@v2.2.1
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.ORG_TOKEN }}
         with:
-          branch: 'cla-signatures'
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/cowprotocol/cla/blob/main/CLA.md'
-          allowlist: '*[bot]'
+          branch: "cla-signatures"
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/cowprotocol/cla/blob/main/CLA.md"
+          allowlist: "*[bot]"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "cow-watch-tower.dnp.dappnode.eth",
-  "version": "0.1.0",
-  "upstreamVersion": "v1.1.1",
+  "version": "0.1.1",
+  "upstreamVersion": "v2.10.0",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "cowprotocol/watch-tower",
   "upstreamArg": "UPSTREAM_VERSION",
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/cowprotocol/dappnodepackage-cow-watch-tower.git"
   },
   "bugs": {
-    "url": "https://github.com/cowprotcool/dappnodepackage-cow-watch-tower/issues"
+    "url": "https://github.com/cowprotocol/dappnodepackage-cow-watch-tower/issues"
   },
   "links": {
     "homepage": "https://cow.fi"
@@ -29,7 +29,11 @@
   ],
   "globalEnvs": [
     {
-      "envs": ["EXECUTION_CLIENT_MAINNET", "EXECUTION_CLIENT_GNOSIS", "EXECUTION_CLIENT_PRATER"],
+      "envs": [
+        "EXECUTION_CLIENT_MAINNET",
+        "EXECUTION_CLIENT_GNOSIS",
+        "EXECUTION_CLIENT_PRATER"
+      ],
       "services": ["watch-tower"]
     }
   ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 version: "3.5"
 services:
   watch-tower:
-    image: "watch-tower.cow-watch-tower.dnp.dappnode.eth:0.1.0"
+    image: watch-tower.cow-watch-tower.dnp.dappnode.eth:0.1.1
     build:
       context: watch-tower
       args:
-        UPSTREAM_VERSION: v1.1.1
+        UPSTREAM_VERSION: v2.10.0
     ports:
-      - "8080:8080/tcp"
+      - 8080:8080/tcp
     environment:
-      NETWORKS: "mainnet,gnosis"
+      NETWORKS: mainnet,gnosis
       ADDRESSES: ""
       PAGE_SIZE: 10000
       LOG_LEVEL: INFO
       EXTRA_OPTS: ""
     restart: unless-stopped
     volumes:
-      - "cow-watch-tower-db:/usr/src/app/database"
+      - cow-watch-tower-db:/usr/src/app/database
 volumes:
   cow-watch-tower-db: {}

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,3 +1,0 @@
-{
-  "signedContributors": []
-}

--- a/watch-tower/Dockerfile
+++ b/watch-tower/Dockerfile
@@ -1,6 +1,6 @@
 ARG UPSTREAM_VERSION
 
-FROM ghcr.io/cowprotocol/watch-tower:pr-112
+FROM ghcr.io/cowprotocol/watch-tower:v2.10.0
 
 RUN apk add --no-cache bash
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewers, including why it is needed -->
reviving watch tower dappnode package?

cla workflow is bugged, see my comment below for workaround instructions

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

- [x] bumped upstream version of `watch-tower` to latest
- [x] some default linting
- [x] bump cla workflow version, although bug that we are currently seeing in this pr might not be fixed. ref: https://github.com/contributor-assistant/github-action/issues/155

## How to test
i was able to successfully run a `dappnodesdk build`, but `dappnodesdk publish` needs to happen from this repo's ci iiuc

## Related Issues

fixes #1; however instead of bumping automatically it pins to latest version (for now)